### PR TITLE
Adds json property in the connection options

### DIFF
--- a/src/nats.ts
+++ b/src/nats.ts
@@ -252,7 +252,9 @@ export interface NatsConnectionOptions {
     /** nkey file path - will automatically setup an `nkey` and `nonceSigner` that references the specified nkey seed file.*/
     nkeyCreds?: string;
     /** number of milliseconds when making a connection to wait for the connection to succeed. Must be greater than zero. */
-    timeout?:number
+    timeout?:number;
+    /** enables the automatic handling of JSON messages */
+    json?: boolean
 }
 
 /** @hidden */


### PR DESCRIPTION
While the library already provided the support for JSON handling, the property in the NatsConnectionOptions interface was missing and so typescript complains about it.

This PR fixes it.