### PR TITLE
tests verifying issues in nats.js not present in nats.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cover:html": "nyc report --reporter=html && open coverage/index.html",
     "cover:coveralls": "nyc report --reporter=lcovonly && cat ./coverage/lcov.info | coveralls",
     "pack": "npm run build && npm pack",
-    "debugtest": "tsc && node $NODE_DEBUG_OPTION node_modules/.bin/ava --verbose -T 6500000 -m",
+    "debugtest": "tsc && node node_modules/.bin/ava --verbose -T 6500000 --match",
     "test": "tsc && nyc ava --verbose -T 15000",
     "doc": "node_modules/.bin/typedoc --options ./typedocconfig.ts && touch ./docs/.nojekyll"
   },


### PR DESCRIPTION
- Changed reference to `Timer` to `Timeout` for heartbeat `pingTimer`
- Simplified heartbeat canceling
- Added tests verifying that permission errors are not fatal
- Added tests to verify that timers for heartbeats, subscriptions, requests are cleared on client close.