### PR TITLE
FIX #72 - Normalize `reconnectTimeWait` and `maxReconnectAttempts`

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -41,9 +41,11 @@ export enum ErrorCode {
     SECURE_CONN_REQ = 'SECURE_CONN_REQ',
     SIGNATURE_REQUIRED = 'SIG_REQ',
     SSL_ERR = 'SSL_ERR',
+    STALE_CONNECTION_ERR = 'STALE CONNECTION',
     SUB_CLOSED = 'SUB_CLOSED',
     SUB_DRAINING = 'SUB_DRAINING',
     SUB_TIMEOUT = 'SUB_TIMEOUT',
+    UNABLE_TO_CONNECT = 'UNABLE_TO_CONNECT',
 
     // emitted by the server
     AUTHORIZATION_VIOLATION = 'AUTHORIZATION_VIOLATION',
@@ -89,6 +91,7 @@ export class Messages {
         this.messages[ErrorCode.SUB_CLOSED] = 'Subscription closed';
         this.messages[ErrorCode.SUB_DRAINING] = 'Subscription draining';
         this.messages[ErrorCode.SUB_TIMEOUT] = 'Subscription timed out.';
+        this.messages[ErrorCode.UNABLE_TO_CONNECT] = 'Unable to connect.';
     }
 
     static getMessage(s: string): string {

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -35,10 +35,10 @@ import {existsSync} from "fs";
 export {ErrorCode, NatsError}
 
 // locate our package.json
-let pkgFile = __dirname + '/../package.json';
+let pkgFile = __dirname + './../package.json';
 if (!existsSync(pkgFile)) {
     // tests will find it here
-    pkgFile = __dirname + '/../../package.json';
+    pkgFile = __dirname + './../../package.json';
 }
 /** Version of the ts-nats library */
 export const VERSION = require(pkgFile).version;

--- a/src/servers.ts
+++ b/src/servers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,6 +25,8 @@ export class Server {
     url: url.Url;
     didConnect: boolean;
     reconnects: number;
+    connects: number;
+    lastConnect: number;
     implicit: boolean;
 
     constructor(u: string, implicit = false) {
@@ -39,6 +41,8 @@ export class Server {
         }
         this.didConnect = false;
         this.reconnects = 0;
+        this.connects = 0;
+        this.lastConnect = 0;
         this.implicit = implicit;
     }
 
@@ -58,6 +62,7 @@ export class Server {
  * @hidden
  */
 export class Servers {
+    private firstSelect : boolean = true;
     private readonly servers: Server[];
     private currentServer: Server;
 
@@ -98,6 +103,11 @@ export class Servers {
     }
 
     selectServer(): Server | undefined {
+        // allow using select without breaking the order of the servers
+        if(this.firstSelect) {
+            this.firstSelect = false;
+            return this.currentServer;
+        }
         let t = this.servers.shift();
         if (t) {
             this.servers.push(t);

--- a/src/tcptransport.ts
+++ b/src/tcptransport.ts
@@ -29,12 +29,14 @@ export class TCPTransport implements Transport {
     stream: net.Socket | TLSSocket | null = null;
     handlers: TransportHandlers;
     closed: boolean = false;
+    dialTime: number = 0;
+
 
     constructor(handlers: TransportHandlers) {
         this.handlers = handlers;
     }
 
-    connect(url: UrlObject): Promise<any> {
+    connect(url: UrlObject, timeout?: number): Promise<any> {
         return new Promise((resolve, reject) => {
             // Create the stream
             // See #45 if we have a stream release the listeners
@@ -43,8 +45,27 @@ export class TCPTransport implements Transport {
                 this.destroy();
             }
             let connected = false;
+            let to: NodeJS.Timeout | undefined;
+            if(timeout) {
+                this.dialTime = Date.now();
+                to = setTimeout(() => {
+                    if (!this.connectedOnce) {
+                        reject(NatsError.errorForCode(ErrorCode.CONN_TIMEOUT));
+                        this.destroy();
+                    } else {
+                        // if the client didn't resolve, the error handler
+                        // is not set, so emitting 'error' will shutdown node
+                        this.handlers.error(NatsError.errorForCode(ErrorCode.CONN_TIMEOUT));
+                    }
+                }, timeout);
+            }
             // @ts-ignore typescript requires this parsed to a number
             this.stream = net.createConnection(parseInt(url.port, 10), url.hostname, () => {
+                if(to) {
+                    this.dialTime = Date.now() - this.dialTime;
+                    clearTimeout(to);
+                    to = undefined;
+                }
                 resolve();
                 connected = true;
                 this.connectedOnce = true;
@@ -159,5 +180,9 @@ export class TCPTransport implements Transport {
         if (this.stream && this.stream.isPaused()) {
             this.stream.resume();
         }
+    }
+
+    dialDuration(): number {
+        return this.dialTime;
     }
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -41,7 +41,7 @@ export interface TransportHandlers {
 export interface Transport {
     close(): void;
 
-    connect(url: url.UrlObject): Promise<Transport>;
+    connect(url: url.UrlObject, timeout?: number): Promise<Transport>;
 
     destroy(): void;
 
@@ -60,5 +60,7 @@ export interface Transport {
     upgrade(tlsOptions: any, done: Function): void;
 
     write(data: Buffer | string): void;
+
+    dialDuration(): number;
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -34,6 +34,12 @@ export function extend(a: any, ...b: any[]): any {
         });
     }
     return a;
+}
+
+export function delay(millis: number): Promise<any> {
+    return new Promise<any>((resolve) => {
+        setTimeout(resolve, millis)
+    })
 }
 
 /**


### PR DESCRIPTION
- Normalize `reconnectTimeWait` and `maxReconnectAttempts` to match other clients.
- Enhanced the `timeout`, to take into account not only the dial portion of the connection but also all the way until the first PONG is processed.