### PR TITLE
Removing existsSync from nats.ts

### DIFF
--- a/src/nats.ts
+++ b/src/nats.ts
@@ -34,7 +34,7 @@ import Timer = NodeJS.Timer;
 export {ErrorCode, NatsError}
 
 /** Version of the ts-nats library */
-export const VERSION = process.env.npm_package_version;
+export const VERSION = require('../package.json').version;
 
 /**
  * @hidden

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -30,12 +30,11 @@ import {
 } from './const';
 import {next} from 'nuid';
 import Timer = NodeJS.Timer;
-import {existsSync} from "fs";
 
 export {ErrorCode, NatsError}
 
 /** Version of the ts-nats library */
-export const VERSION = require('../package.json').version;
+export const VERSION = process.env.npm_package_version;
 
 /**
  * @hidden


### PR DESCRIPTION
Our project imports ts-nats in non-NodeJS environments where existsSync wasn't available which was causing errors to our users, I've removed its import from the `nats.ts` file ~~and also replaced VERSION to be accessible from environment variable~~