### PR TITLE
Jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,9 @@ The following is the list of connection options and default values.
 | `pedantic`             | `false`                   | Turns on strict subject format checks
 | `pingInterval`         | `120000`                  | Number of milliseconds between client-sent pings
 | `reconnect`            | `true`                    | If false server will not attempt reconnecting
+| `reconnectJitter`      | `100`                     | Number of millis to randomize after `reconnectTimeWait`. See [jitter](#jitter).
+| `reconnectJitterTLS`   | `1000`                    | Number of millis to randomize after `reconnectTimeWait` when TLS options are specified. See [jitter](#jitter).
+| `reconnectDelayHandler`| Generated function        | A function that returns the number of millis to wait before the next connection to a server it connected to. See [jitter](#jitter).
 | `reconnectTimeWait`    | `2000`                    | If disconnected, the client will wait the specified number of milliseconds between reconnect attempts
 | `servers`              |                           | Array of connection `url`s
 | `timeout`              | `0`                       | Number of milliseconds to wait before timing out the initial connection. Must be greater than `0`. Note that `waitOnFirst` must be specified, and `reconnectTimeWait` and `maxReconnectAttempts` must have sensible values supporting the desired timeout.
@@ -487,6 +490,21 @@ The following is the list of connection options and default values.
 | `waitOnFirstConnect`   | `false`                   | If `true` the server will fall back to a reconnect mode if it fails its first connection attempt.
 | `yieldTime`            |                           | If set and processing exceeds yieldTime, client will yield to IO callbacks before processing additional inbound messages 
 
+
+### Jitter 
+
+The settings `reconnectTimeWait`, `reconnectJitter`, `reconnectJitterTLS`, `reconnectDelayHandler` are all related.
+They control how long before the NATS client attempts to reconnect to a server it has previously connected.
+
+The intention of the settings is to spread out the number of clients attempting to reconnect to a server over a period of time, 
+and thus preventing a ["Thundering Herd"](https://docs.nats.io/developing-with-nats/reconnect/random).
+
+The relationship between these is:
+
+- If `reconnectDelayHandler` is specified, the client will wait the value returned by this function. No other value will be taken into account.
+- If the client specified TLS options, the client will generate a number between 0 and `reconnectJitterTLS` and add it to
+`reconnectTimeWait`.
+- If the client didn't specify TLS options, the client will generate a number between 0 and `reconnectJitter` and add it to `reconnectTimeWait`.
 
 
 ## Supported Node Versions    

--- a/src/const.ts
+++ b/src/const.ts
@@ -22,6 +22,8 @@ export const DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT;
 // Reconnect Parameters, 2 sec wait, 10 tries
 export const DEFAULT_RECONNECT_TIME_WAIT = 2 * 1000;
 export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
+export const DEFAULT_JITTER = 100;
+export const DEFAULT_JITTER_TLS = 1000;
 
 // Ping interval
 export const DEFAULT_PING_INTERVAL = 2 * 60 * 1000; // 2 minutes

--- a/src/error.ts
+++ b/src/error.ts
@@ -32,11 +32,12 @@ export enum ErrorCode {
     CONN_TIMEOUT = 'CONN_TIMEOUT',
     INVALID_ENCODING = 'INVALID_ENCODING',
     NKEY_OR_JWT_REQ = 'NKEY_OR_JWT_REQ',
-    NONCE_SIGNER_NOTFUNC = 'NONCE_SIGNER_NOT_FUNC',
-    NON_SECURE_CONN_REQ = 'NON_SECURE_CONN_REQ',
     NO_ECHO_NOT_SUPPORTED = 'NO_ECHO_NOT_SUPPORTED',
     NO_SEED_IN_CREDS = 'NO_SEED_IN_CREDS',
     NO_USER_JWT_IN_CREDS = 'NO_USER_JWT_IN_CREDS',
+    NON_SECURE_CONN_REQ = 'NON_SECURE_CONN_REQ',
+    NONCE_SIGNER_NOTFUNC = 'NONCE_SIGNER_NOT_FUNC',
+    RECONNECT_DELAY_NOTFUNC = "RECONNECT_DELAY_NOT_FUNC",
     REQ_TIMEOUT = 'REQ_TIMEOUT',
     SECURE_CONN_REQ = 'SECURE_CONN_REQ',
     SIGNATURE_REQUIRED = 'SIG_REQ',
@@ -88,6 +89,7 @@ export class Messages {
         this.messages[ErrorCode.NON_SECURE_CONN_REQ] = 'Server does not support a secure connection.';
         this.messages[ErrorCode.NONCE_SIGNER_NOTFUNC] = 'nonce signer is not a function';
         this.messages[ErrorCode.REQ_TIMEOUT] = 'Request timed out.';
+        this.messages[ErrorCode.RECONNECT_DELAY_NOTFUNC] = "reconnectDelayHandler is not a function";
         this.messages[ErrorCode.SECURE_CONN_REQ] = 'Server requires a secure connection.';
         this.messages[ErrorCode.SIGNATURE_REQUIRED] = 'Server requires an nkey signature.';
         this.messages[ErrorCode.SSL_ERR] = 'TLS credentials verification failed';

--- a/src/protocolhandler.ts
+++ b/src/protocolhandler.ts
@@ -135,7 +135,8 @@ export class ProtocolHandler extends EventEmitter {
         return new Promise<ProtocolHandler>(async(resolve, reject) => {
             let ph = new ProtocolHandler(client, opts);
             while(true) {
-                let wait = ph.options.reconnectTimeWait || 0;
+                // @ts-ignore
+                let wait = ph.options.reconnectDelayHandler();
                 let maxWait = wait;
                 for (let i=0; i < ph.servers.length(); i++) {
                     const srv = ph.selectServer();
@@ -1034,7 +1035,8 @@ export class ProtocolHandler extends EventEmitter {
         if (this.wasConnected) {
             this.reconnecting = true;
         }
-        let wait = this.options.reconnectTimeWait || 0;
+        //@ts-ignore
+        let wait = this.options.reconnectDelayHandler();
         let maxWait = wait;
         const now = Date.now();
         for (let i=0; i < this.servers.length(); i++) {

--- a/src/tcptransport.ts
+++ b/src/tcptransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Added the ability to specify jitter parameters. The jitter is an extra amount of time that is random up to specified value which is added to the standard `reconnectTimeWait`. Two values are exposed `reconnectJitter` and `reconnectJitterTLS`. In addition, there's a `reconnectDelayHandler` where a client can specify a value (in milliseconds) that will be used for delay between reconnects.